### PR TITLE
fix(ci): string interpolation for release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     with:
       # TODO: change this when we actually want to cutover the charm to main
       # channels
-      channel: ${{ needs.get-version.outputs.version }}-ops/edge
+      channel: "${{ needs.get-version.outputs.version }}-ops/edge"
       artifact-prefix: ${{ needs.ci.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
This fixes the string interpolation for release job to get the version correctly passed from the get-version workflow.