### PR TITLE
fix(ci): use correct version variable to pass into the release job

### DIFF
--- a/.github/workflows/get-version.yaml
+++ b/.github/workflows/get-version.yaml
@@ -1,4 +1,4 @@
-name: Get current version
+name: Get current charm version
 
 on:
   workflow_call:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   get-version:
+    name: Get Charm Version
     uses: ./.github/workflows/get-version.yaml
 
   ci:
@@ -26,7 +27,7 @@ jobs:
       snap_risk_level: edge
 
   release:
-    name: Release charm
+    name: Release to edge
     needs:
       - ci
       - get-version
@@ -34,7 +35,7 @@ jobs:
     with:
       # TODO: change this when we actually want to cutover the charm to main
       # channels
-      channel: "${{ needs.get-version.outputs.version }}-ops/edge"
+      channel: "${{ needs.get-version.outputs.charm_version }}-ops/edge"
       artifact-prefix: ${{ needs.ci.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
This commit fixes the variable name to refer to the correct output variable name `charm_version` instead of `version`.